### PR TITLE
Roadmap web v3 profesional: Gantt auto-programado, deps, filtros, camino crítico

### DIFF
--- a/docs/tfm/roadmap.md
+++ b/docs/tfm/roadmap.md
@@ -2,33 +2,18 @@
 
 [← Volver al TFM](README.md)
 
-Este documento traduce las **cinco fases** de la metodología (Cap. 3 de la memoria) en un
-plan técnico **capa a capa**, marcando qué existe ya, qué falta y **dónde están los riesgos
-que la memoria no detalla**. Es el documento de trabajo para las **Entregas 2 y 3**
-(Cap. 4 *Desarrollo específico de la contribución* y Cap. 5 *Conclusiones*).
+!!! tip "📊 El estado vivo del proyecto está en el tablero: [roadmap.iawiki.app](https://roadmap.iawiki.app)"
+    Tareas, subtareas, dependencias, **Gantt auto-programado**, camino crítico e historial —
+    todo se gestiona en el **[tablero web compartido](https://roadmap.iawiki.app)**
+    (código en `tools/roadmap-web/`). Esta página recoge únicamente el **marco conceptual**
+    que da contexto a la memoria: capas, decisiones de diseño y riesgos.
 
-!!! tip "Estado vivo del roadmap → [roadmap.iawiki.app](https://roadmap.iawiki.app)"
-    El **estado actualizado** de cada tarea (pendiente/en curso/hecho, asignaciones e
-    historial) se mantiene en el **[tablero web compartido](https://roadmap.iawiki.app)**
-    (código en `tools/roadmap-web/`). Este documento recoge el **plan conceptual**: capas,
-    hitos, dependencias y decisiones — lo que no cambia semana a semana.
+## Diagrama conceptual por capas
 
-!!! info "Estado global (a jul 2026)"
-    **Entrega 1 completada** (Cap. 1-3: problema, estado del arte, objetivos y metodología).
-    Implementación **en curso**: hitos **0.1 (Humble)** ✅ y **0.2 (puente `/cmd_vel`)** ✅
-    completados. Restricción operativa: **el hardware del coche no se modifica** — las pruebas
-    de tracción siguen un protocolo de rampas suaves (la alimentación única Pi/motores hace
-    que las entradas escalón provoquen brownouts). Siguiente frente: 0.3 (URDF/TF), `/scan`
-    del LIDAR y MCP Server (paralelizables).
-
-Leyenda de estado: ✅ hecho · 🟡 parcial · ⬜ pendiente
-
-## 1. Diagrama conceptual por capas
-
-La solución se organiza en cuatro capas. Las tres capas superiores son las que describe la
-memoria (Percepción, Navegación, Interfaz natural); la **Capa 0** recoge los fundamentos ROS2
-(URDF/TF, odometría y puente de actuación) que la memoria da por supuestos pero que hay que
-construir explícitamente y concentran el mayor riesgo del proyecto.
+La solución se organiza en cuatro capas. Las tres superiores son las que describe la memoria
+(Percepción, Navegación, Interfaz natural); la **Capa 0** recoge los fundamentos ROS2
+(URDF/TF, odometría y puente de actuación) que la memoria da por supuestos y que concentran
+el riesgo técnico — su explicación detallada está en [Fundamentos ROS2](fundamentos.md).
 
 ```mermaid
 flowchart TB
@@ -52,7 +37,7 @@ flowchart TB
       carto["Cartographer 2D<br/>→ /map + trayectoria"]
     end
 
-    subgraph L0["Capa 0 — Fundamentos ROS2 (riesgo principal)"]
+    subgraph L0["Capa 0 — Fundamentos ROS2"]
       direction TB
       tf["URDF + árbol TF<br/>base_link · laser"]
       odom["Odometría<br/>encoders + IMU"]
@@ -77,119 +62,23 @@ flowchart TB
     hw --> odom
 ```
 
-!!! note "Cómo leer el diagrama"
-    El flujo de **control** baja de arriba abajo (usuario → LLM → MCP → Nav2 → hardware) y el
-    flujo de **percepción** sube (hardware → `/scan` → Cartographer → Nav2). La Capa 0 sostiene
-    a las dos: sin un TF y una odometría coherentes, ni Cartographer ni Nav2 funcionan, y sin el
-    puente `/cmd_vel → PCA9685` la salida de Nav2 no llega a las ruedas.
+El **panel de control web** (`tools/car-panel/`, servido desde el propio vehículo) es
+**transversal a todas las capas**: cada una aterriza visualmente en él (scan y sensores hoy;
+mapa, navegación y chat LLM conforme avancen las capas). Actúa como mecanismo de observación
+y pruebas de todo el sistema.
 
-## 2. Roadmap por capas
+## Decisiones de diseño
 
-### Capa 0 — Fundamentos ROS2 *(pre-requisito, no explícito en la memoria)*
+| ID | Decisión | Resolución |
+|---|---|---|
+| **D1** | Distro ROS2 | **Humble** (LTS hasta 2027, alineada con la memoria). Migración realizada. |
+| **D2** | Odometría/localización | **Opción A**: pose por *scan-matching* de Cartographer. Plan B preparado (fusión encoder+IMU → odometría modelo-bicicleta) si no se cumple OE1 (<10 cm). |
+| **D3** | Controlador local Nav2 | **TEB** (o RPP/MPPI) por la cinemática Ackermann — no el DWB diferencial. Datos ya disponibles: L=0.175 m, radio de giro mín. 0.175 m, velocidad operativa 0.18 m/s. |
+| **D4** | Puente de actuación | `car_control_node` extendido (único dueño del bus I2C): `/cmd_vel` → servo dirección + ESC, con rampa anti-pico, watchdog y neutro garantizado. |
 
-Antes de SLAM hay que resolver lo que la metodología da por hecho. La explicación conceptual
-detallada (Ackermann, URDF/TF, odometría y por qué es el riesgo principal) está en
-[Fundamentos ROS2](fundamentos.md).
+## Correspondencia fases ↔ capas ↔ objetivos
 
-!!! abstract "Estado de la plataforma (Raspberry Pi `robocar.local`, user `lab`) — jul 2026"
-    - **Ubuntu 22.04.4 LTS**, Python 3.10.12. ROS2 **Iron** instalado; **Humble** confirmado
-      instalable por apt (`ros-humble-navigation2` disponible).
-    - **Stack del TFM sin instalar**: no hay Nav2, Cartographer, rplidar_ros ni robot_localization
-      (solo `joy`). Partimos de cero en navegación → bajo coste de migrar a Humble.
-    - Workspace en `/home/lab/robocar`, rama **TFG_2** (por detrás de `main`).
-    - `robocar.service` (systemd, `User=lab` → `launch.sh`) existe y está **disabled**.
-    - ⚠️ **LIDAR no conectado** ahora mismo (sin `/dev/ttyUSB*`). ⚠️ Disco al **85%** (4.2 GB libres).
-
-Plan incremental de hitos (cada uno con una validación testable):
-
-| Hito | Objetivo | Cómo se valida | Decisión |
-|---|---|---|---|
-| **0.1** ✅ | **Migrar a Humble**: instalar `ros-humble-ros-base` + deps, recompilar workspace (`robocar_pkg`, `messages_pkg`, `teleop_twist_joy`), limpiar el entry point `controller_node` colgante; purgar Iron tras validar | `colcon build` limpio y nodos TFG arrancan en Humble | **D1 ✔ Humble** |
-| **0.2** ✅ | **Puente `/cmd_vel` → PCA9685** (Ackermann): `angular.z`→servo dirección (canal 2), `linear.x`→ESC (canales 0/1); calibrar velocidad máx., ángulo de dirección máx. y *wheelbase*. Refactor del modo autónomo actual de `car_control_node` | **Conducir el coche con el mando** vía `/cmd_vel` (teleop_twist_joy ya lo emite) | D4 |
-| **0.3** | **URDF + TF**: `xacro` con `base_link`, `laser` (offset del montaje), `imu_link` y ruedas; `robot_state_publisher` + transforms estáticos | Árbol TF coherente en RViz (`base_link → laser`) | — |
-| **0.4** | **Odometría**: con D2=A no se monta odom de ruedas; se deja a Cartographer estimar la pose por *scan-matching*. Reservado el nodo encoder + modelo-bicicleta para la opción B | Se valida en la Capa 1 (pose estable en Cartographer) | **D2 ✔ A** |
-| **0.5** | **Sanear `/imu`**: añadir `header` (timestamp + `frame_id`) y covarianzas a `accelerometer_node` | `/imu` válido para `robot_localization` (solo crítico si se migra a D2=B) | (D2) |
-
-!!! warning "Cinemática Ackermann"
-    Robocar **no es un robot diferencial**: dirige con un servo (tipo coche). Esto afecta al
-    puente de actuación y a la elección de controlador local en la Capa 2. Es la diferencia
-    conceptual más importante frente a los tutoriales estándar de Nav2 (pensados para
-    TurtleBot diferencial).
-
-!!! tip "Victoria temprana en 0.2"
-    El `launch.sh` ya arranca `teleop_twist_joy`, que publica `/cmd_vel` desde el mando, pero hoy
-    `car_control_node` lee `/joy` en crudo y ese `/cmd_vel` se ignora. Reaprovecharlo permite
-    **validar el puente Ackermann con el mando antes de que exista Nav2**. Con 0.1 + 0.2 + 0.3
-    hechos, la Capa 1 (SLAM) puede arrancar.
-
-### Capa 1 — Percepción / SLAM *(Fase 1 · 3-4 semanas)*
-
-- [ ] 🟡 **Sensor validado** a nivel hardware fuera de ROS2 (`pruebas/rplidar/`) — reutilizable como referencia.
-- [ ] ⬜ **`rplidar_ros`** integrado publicando `/scan` (`sensor_msgs/LaserScan`) dentro de ROS2.
-- [ ] ⬜ **Cartographer 2D** configurado (`.lua`) y ajustado a Raspberry Pi (resolución y frecuencia de optimización contenidas).
-- [ ] ⬜ **Mapa del entorno** construido por teleoperación (mando PS3) y guardado (`.pgm` + `.yaml`).
-- [ ] ⬜ **Base de datos SQLite** de lugares semánticos (nombre → coordenada en el mapa; ≥ 3 lugares).
-
-!!! success "Puerta de validación — OE1"
-    Mapa coherente y estable + localización reproducible con **error < 10 cm**.
-
-### Capa 2 — Navegación *(Fase 2 · 3-4 semanas)*
-
-- [ ] ⬜ **Nav2** configurado: BT Navigator, planner global (NavFn/Smac), costmaps (static + inflation + obstacle) y AMCL.
-- [ ] ⬜ **Controlador local Ackermann**: **TEB** (o Regulated Pure Pursuit / MPPI), **no** el DWB diferencial (ver [Decisión D3](#3-decisiones-de-diseno)).
-- [ ] ⬜ **Servicio de resolución semántica** (lee la SQLite: nombre de lugar → `PoseStamped`).
-- [ ] ⬜ **Navegación punto a punto** validada entre waypoints en entorno controlado.
-
-!!! success "Puerta de validación — OE2"
-    **Tasa de éxito > 90 %** (≥ 20 ensayos, destino dentro de radio de 20 cm).
-
-### Capa 3 — Interfaz natural / LLM + MCP *(Fases 3-4 · 4-6 semanas)*
-
-- [ ] ⬜ **MCP Server** en Python con **FastMCP** y las 4 herramientas: `navigate_to()`, `get_current_location()`, `list_known_places()`, `stop_navigation()`.
-- [ ] ⬜ **Cliente de acción `rclpy`** contra `NavigateToPose` (envío de meta, feedback, éxito/fallo/cancelación).
-- [ ] ⬜ **Host + Claude API**: system prompt del asistente de navegación y bucle conversacional con *tool use*.
-
-!!! success "Puertas de validación — OE3 / OE4"
-    Herramientas invocables manualmente con comportamiento correcto (OE3) y **pipeline
-    end-to-end** desde texto del usuario hasta movimiento del robot (OE4).
-
-!!! tip "Se puede adelantar"
-    El MCP Server puede desarrollarse y probarse contra un **Nav2 simulado (mock)** sin esperar
-    a que la Capa 2 esté cerrada, para no bloquear el trabajo de la interfaz.
-
-### Capa 4 — Validación y cierre *(Fase 5 · 2-3 semanas)*
-
-- [ ] ⬜ **Batería de pruebas** end-to-end: comandos simples, secuencias compuestas y casos de error.
-- [ ] ⬜ **Toma de métricas** (OE1-OE4) y refinamiento de casos de fallo.
-- [ ] ⬜ **Redacción** del Cap. 4 (desarrollo) y Cap. 5 (conclusiones y líneas futuras) + Resumen/Abstract.
-
-## 3. Decisiones de diseño
-
-| ID | Decisión | Estado | Detalle |
-|---|---|---|---|
-| **D1** | Distro ROS2 | ✅ **Humble** | El stack del TFM no está instalado bajo ninguna distro, así que migrar a Humble (LTS, lo que dice la memoria) tiene coste casi nulo. Instalar junto a Iron y purgar Iron tras validar. Alinear el README (dice Iron). |
-| **D2** | Odometría/localización | ✅ **Opción A ahora** | Empezar con la pose por *scan-matching* de Cartographer (sin odometría de ruedas). Migrar a **B** (encoders + IMU con `robot_localization` EKF + AMCL) **solo si** no se cumple OE1 (< 10 cm); en ese caso, documentarla en el Cap. 4 (no está en la memoria). |
-| **D3** | Controlador local Nav2 | 🟡 Previsto | **TEB** (o Regulated Pure Pursuit / MPPI) por la cinemática Ackermann; **no** el DWB diferencial. La propia memoria lo señala. Se cierra en la Capa 2. |
-| **D4** | Puente de actuación | 🟡 Previsto | Refactor del modo autónomo de `car_control_node` (o nodo nuevo) que traduzca `/cmd_vel` (`Twist`) a ángulo de servo (canal 2) + throttle ESC (canales 0/1) respetando límites Ackermann. Se implementa en el hito 0.2. |
-
-## 4. Camino crítico y riesgos
-
-!!! danger "Dónde se atascan los TFM de robótica"
-    El riesgo **no está en el LLM ni en el MCP** (es la parte más acotada y controlable), sino
-    en la **Capa 0-2**: TF, odometría y el puente Ackermann. Ahí conviene invertir el esfuerzo.
-
-- **Secuencialidad estricta hasta la Capa 3**: sin `/scan` en ROS2 no hay mapa; sin mapa no hay
-  Nav2; sin Nav2 no hay acción que el MCP invoque. La única paralelización razonable es
-  adelantar el MCP Server contra un Nav2 *mock*.
-- **Cómputo en la Pi 4 (4 GB)**: `rplidar_ros` + Cartographer + Nav2 juntos van justos pero son
-  viables (equivalente a TurtleBot3). El LLM corre **fuera** de la Pi vía Claude API, así que no
-  añade carga local.
-- **Odometría Ackermann**: es la incógnita técnica principal (Decisión D2) y afecta directamente
-  a OE1 y OE2.
-
-## 5. Correspondencia fases ↔ capas ↔ objetivos
-
-| Fase (memoria) | Capa (este roadmap) | Objetivo | Métrica |
+| Fase (memoria) | Capa | Objetivo | Métrica |
 |---|---|---|---|
 | Fase 1 · SLAM y mapa semántico | Capa 0 + Capa 1 | OE1 | Error localización < 10 cm |
 | Fase 2 · Navegación con Nav2 | Capa 2 | OE2 | Éxito navegación > 90 % |
@@ -197,10 +86,12 @@ Plan incremental de hitos (cada uno con una validación testable):
 | Fase 4 · Integración con LLM | Capa 3 | OE4 | Interpretación NL > 85 % |
 | Fase 5 · Pruebas y evaluación | Capa 4 | OE1-OE4 | + latencia mediana < 5 s |
 
-## 6. Pendientes de la memoria *(pulido, no urgente)*
+## Riesgos estructurales
 
-- **Distro descuadrada**: el repo/README indica **Iron** y la memoria **Humble** (Decisión D1).
-- **Referencias de los TFG previos**: en la bibliografía la autoría/año de los dos TFG aparece
-  cruzada respecto al cuerpo del texto (construcción como 2023 individual, lane-following como
-  2024 a dos autores; en el cuerpo es al revés). Revisar antes de la entrega final.
-- **Odometría/EKF**: si se adopta la opción D2-B, documentarla en el Cap. 4.
+- **Capa 0 como cuello de botella**: TF, odometría y actuación Ackermann son el trabajo
+  "invisible" del que depende todo lo demás (ver [Fundamentos ROS2](fundamentos.md)).
+- **Cómputo en la Raspberry Pi 4**: LIDAR + Cartographer + panel comparten CPU; el tuning
+  de Cartographer (submaps y optimización contenidos) es parte del diseño.
+- **Alimentación única** (batería → ESC + BUCK 5V compartido): las entradas de acelerador
+  en escalón provocan caídas de tensión; se gestiona con rampas por software y protocolo
+  operativo (el hardware no se modifica, por decisión de proyecto).

--- a/tools/roadmap-web/app.py
+++ b/tools/roadmap-web/app.py
@@ -81,10 +81,15 @@ def init_db():
             );
             """
         )
-        # Migración no destructiva: subtareas (parent_id) sobre BDs existentes.
+        # Migraciones no destructivas sobre BDs existentes.
         cols = [r["name"] for r in conn.execute("PRAGMA table_info(tasks)")]
         if "parent_id" not in cols:
             conn.execute("ALTER TABLE tasks ADD COLUMN parent_id INTEGER REFERENCES tasks(id)")
+        if "estimate_days" not in cols:
+            conn.execute("ALTER TABLE tasks ADD COLUMN estimate_days REAL DEFAULT 1.0")
+            conn.execute("ALTER TABLE tasks ADD COLUMN start_date TEXT")   # fija manual (opcional)
+            conn.execute("ALTER TABLE tasks ADD COLUMN due_date TEXT")     # fija manual (opcional)
+            conn.execute("ALTER TABLE tasks ADD COLUMN done_at INTEGER")   # epoch al completarse
         if conn.execute("SELECT COUNT(*) c FROM layers").fetchone()["c"] == 0:
             seed(conn)
 
@@ -212,7 +217,8 @@ def remove_dep(task_id: int, dep_id: int,
     return {"ok": True}
 
 
-TASK_FIELDS = {"title", "detail", "status", "assignee", "position", "layer_id", "parent_id"}
+TASK_FIELDS = {"title", "detail", "status", "assignee", "position", "layer_id", "parent_id",
+               "estimate_days", "start_date", "due_date", "done_at"}
 DECISION_FIELDS = {"code", "title", "status", "detail"}
 LAYER_FIELDS = {"title", "subtitle", "position"}
 
@@ -227,6 +233,9 @@ async def patch_row(request: Request, table: str, row_id: int, allowed: set,
         row = conn.execute(f"SELECT * FROM {table} WHERE id=?", (row_id,)).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="No existe")
+        # Al completar una tarea se sella done_at (y se limpia si se reabre).
+        if table == "tasks" and "status" in body:
+            body = dict(body, done_at=int(time.time()) if body["status"] == "done" else None)
         sets = ", ".join(f"{k}=?" for k in body)
         conn.execute(f"UPDATE {table} SET {sets} WHERE id=?", (*body.values(), row_id))
         if "status" in body:

--- a/tools/roadmap-web/static/app.js
+++ b/tools/roadmap-web/static/app.js
@@ -80,6 +80,72 @@ function pickTask(excludeId) {
   return Number.isFinite(id) ? id : null;
 }
 
+/* ---------- diagrama de dependencias (SVG, sin librerías) ---------- */
+function renderDepGraph() {
+  const host = $("#depGraph");
+  if (!host) return;
+  const deps = state.deps || [];
+  if (!deps.length) { host.innerHTML = '<div class="muted">sin dependencias todavía</div>'; return; }
+
+  // solo participan las tareas con alguna arista
+  const inGraph = new Set();
+  deps.forEach(d => { inGraph.add(d.task_id); inGraph.add(d.depends_on_id); });
+  const nodes = state.tasks.filter(t => inGraph.has(t.id));
+
+  // capa = camino más largo desde una raíz (orden topológico por niveles)
+  const dmap = {};
+  deps.forEach(d => (dmap[d.task_id] = dmap[d.task_id] || []).push(d.depends_on_id));
+  const layerOf = {};
+  const calc = (id, seen) => {
+    if (layerOf[id] !== undefined) return layerOf[id];
+    seen = seen || new Set();
+    if (seen.has(id)) return 0;
+    seen.add(id);
+    const ds = dmap[id] || [];
+    return (layerOf[id] = ds.length ? Math.max(...ds.map(x => calc(x, seen))) + 1 : 0);
+  };
+  nodes.forEach(n => calc(n.id));
+
+  const byLayer = [];
+  nodes.forEach(n => (byLayer[layerOf[n.id]] = byLayer[layerOf[n.id]] || []).push(n));
+
+  const NW = 150, NH = 34, GX = 14, ROW = 88, PAD = 18;
+  const maxRow = Math.max(...byLayer.map(r => (r ? r.length : 0)));
+  const W = Math.max(maxRow * (NW + GX) + PAD * 2, 420);
+  const H = byLayer.length * ROW + PAD;
+
+  const pos = {};
+  byLayer.forEach((row, l) => {
+    if (!row) return;
+    row.sort((a, b) => a.layer_id - b.layer_id || a.id - b.id);
+    const total = row.length * (NW + GX) - GX;
+    row.forEach((n, i) => { pos[n.id] = { x: (W - total) / 2 + i * (NW + GX), y: PAD + l * ROW }; });
+  });
+
+  const col = t => t.status === "done" ? "#3fb96b"
+    : t.status === "in_progress" ? "#e0a83c"
+    : isBlocked(t) ? "#e05c5c" : "#8a93a6";
+
+  let svg = "";
+  for (const d of deps) {
+    const a = pos[d.depends_on_id], b = pos[d.task_id];
+    if (!a || !b) continue;
+    const x1 = a.x + NW / 2, y1 = a.y + NH, x2 = b.x + NW / 2, y2 = b.y;
+    svg += `<path d="M${x1},${y1} C${x1},${y1 + 36} ${x2},${y2 - 36} ${x2},${y2}" fill="none" stroke="#2a3348" stroke-width="1.5" marker-end="url(#arr)"/>`;
+  }
+  for (const n of nodes) {
+    const p = pos[n.id], c = col(n);
+    const label = n.title.length > 21 ? n.title.slice(0, 20) + "…" : n.title;
+    svg += `<g><rect x="${p.x}" y="${p.y}" width="${NW}" height="${NH}" rx="8" fill="#1d2537" stroke="${c}" stroke-width="1.6"/>
+      <circle cx="${p.x + 13}" cy="${p.y + NH / 2}" r="4" fill="${c}"/>
+      <text x="${p.x + 24}" y="${p.y + NH / 2 + 4}" fill="#e8ecf4" font-size="11">${esc(label)}</text>
+      <title>${esc(n.title)} — ${n.status}${isBlocked(n) ? " (bloqueada)" : ""}</title></g>`;
+  }
+  host.innerHTML = `<svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">
+    <defs><marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#2a3348"/></marker></defs>
+    ${svg}</svg>`;
+}
+
 function render() {
   const { layers, tasks, decisions, events } = state;
 
@@ -147,6 +213,8 @@ function render() {
     };
     dv.appendChild(el);
   }
+
+  renderDepGraph();
 
   // historial
   const ev = $("#events");

--- a/tools/roadmap-web/static/app.js
+++ b/tools/roadmap-web/static/app.js
@@ -80,8 +80,108 @@ function pickTask(excludeId) {
   return Number.isFinite(id) ? id : null;
 }
 
+/* ---------- filtros (persona / estado), persistidos en el navegador ---------- */
+function getFilters() { try { return JSON.parse(localStorage.getItem("roadmap_filters")) || {}; } catch { return {}; } }
+function setFilters(f) { localStorage.setItem("roadmap_filters", JSON.stringify(f)); render(); }
+function taskMatches(t) {
+  const f = getFilters();
+  if (f.who) {
+    if (f.who === "(sin)") { if (t.assignee) return false; }
+    else if (!(t.assignee || "").toLowerCase().includes(f.who.toLowerCase())) return false;
+  }
+  if (f.st && t.status !== f.st) return false;
+  return true;
+}
+function getCollapsed() { try { return new Set(JSON.parse(localStorage.getItem("roadmap_collapsed")) || []); } catch { return new Set(); } }
+
+/* ---------- planificación auto-programada (camino crítico por deps) ---------- */
+const DAY = 86400000;
+const fmtDate = ts => new Date(ts).toLocaleDateString("es-ES", { day: "2-digit", month: "short" });
+
+function computeSchedule() {
+  const dmap = {};
+  (state.deps || []).forEach(d => (dmap[d.task_id] = dmap[d.task_id] || []).push(d.depends_on_id));
+  const byId = {}; state.tasks.forEach(t => byId[t.id] = t);
+  const memo = {}, now = Date.now();
+  function calc(id, seen) {
+    if (memo[id]) return memo[id];
+    seen = seen || new Set();
+    if (seen.has(id) || !byId[id]) return { s: now, f: now };
+    seen.add(id);
+    const t = byId[id];
+    const est = Math.max(t.estimate_days || 1, 0.25) * DAY;
+    if (t.status === "done") {
+      const f = t.done_at ? t.done_at * 1000 : now;
+      return memo[id] = { s: f - est, f, done: true };
+    }
+    // inicio = hoy, o la fecha fija manual, o el fin de la última dependencia pendiente
+    let s = now;
+    if (t.start_date) { const m = Date.parse(t.start_date); if (m) s = Math.max(s, m); }
+    for (const d of (dmap[id] || [])) { const r = calc(d, seen); if (!r.done) s = Math.max(s, r.f); }
+    let f = s + est;
+    if (t.due_date) { const m = Date.parse(t.due_date); if (m) f = Math.max(s + DAY / 4, m + DAY); }
+    return memo[id] = { s, f };
+  }
+  state.tasks.forEach(t => calc(t.id));
+  // camino crítico: la cadena que fija el fin más tardío del proyecto
+  const crit = new Set();
+  let cur = null, maxF = -1;
+  for (const t of state.tasks) {
+    const m = memo[t.id];
+    if (t.status !== "done" && m && m.f > maxF) { maxF = m.f; cur = t.id; }
+  }
+  while (cur != null && !crit.has(cur)) {
+    crit.add(cur);
+    let next = null, bestF = -1;
+    for (const d of (dmap[cur] || [])) {
+      const m = memo[d];
+      if (m && !m.done && m.f > bestF) { bestF = m.f; next = d; }
+    }
+    cur = next;
+  }
+  return { sched: memo, crit, projectEnd: maxF > 0 ? maxF : null };
+}
+
+/* ---------- Gantt (SVG, sin librerías) ---------- */
+function renderGantt(plan) {
+  const host = $("#gantt");
+  if (!host) return;
+  const rows = state.tasks.filter(t => taskMatches(t) && plan.sched[t.id])
+    .sort((a, b) => plan.sched[a.id].s - plan.sched[b.id].s);
+  if (!rows.length) { host.innerHTML = '<div class="muted">sin tareas que mostrar</div>'; return; }
+  const now = Date.now();
+  const min = Math.min(now, ...rows.map(t => plan.sched[t.id].s)) - DAY;
+  const max = Math.max(now, ...rows.map(t => plan.sched[t.id].f)) + DAY;
+  const PXD = 26, LBL = 215, RH = 24, HDR = 28;
+  const days = Math.ceil((max - min) / DAY);
+  const W = LBL + days * PXD, H = HDR + rows.length * RH + 8;
+  const x = ts => LBL + (ts - min) / DAY * PXD;
+  let svg = "";
+  for (let d = 0; d <= days; d++) {
+    const ts = min + d * DAY, dt = new Date(ts), wd = dt.getDay(), gx = LBL + d * PXD;
+    if (wd === 0 || wd === 6) svg += `<rect x="${gx}" y="${HDR}" width="${PXD}" height="${H - HDR}" fill="#141a28" opacity="0.6"/>`;
+    if (wd === 1) svg += `<line x1="${gx}" y1="${HDR - 6}" x2="${gx}" y2="${H}" stroke="#1c2333"/>` +
+      `<text x="${gx + 3}" y="${HDR - 12}" fill="#8a93a6" font-size="10">${dt.getDate()}/${dt.getMonth() + 1}</text>`;
+  }
+  svg += `<line x1="${x(now)}" y1="${HDR - 6}" x2="${x(now)}" y2="${H}" stroke="#5aa2ff" stroke-width="1.5" stroke-dasharray="4 3"/>` +
+         `<text x="${x(now) + 4}" y="${HDR}" fill="#5aa2ff" font-size="10">HOY</text>`;
+  rows.forEach((t, i) => {
+    const m = plan.sched[t.id], y = HDR + i * RH + 4;
+    const c = t.status === "done" ? "#3fb96b" : t.status === "in_progress" ? "#e0a83c" : isBlocked(t) ? "#5c6577" : "#5aa2ff";
+    const isCrit = plan.crit.has(t.id);
+    const label = t.title.length > 31 ? t.title.slice(0, 30) + "…" : t.title;
+    svg += `<text x="4" y="${y + 12}" fill="${t.status === "done" ? "#8a93a6" : "#e8ecf4"}" font-size="11">${esc(label)}</text>`;
+    svg += `<rect x="${x(m.s)}" y="${y}" width="${Math.max(x(m.f) - x(m.s), 5)}" height="15" rx="4" fill="${c}" opacity="${t.status === "done" ? 0.5 : 0.9}"${isCrit ? ' stroke="#e05c5c" stroke-width="1.8"' : ""}>` +
+      `<title>${esc(t.title)} — ${fmtDate(m.s)} → ${fmtDate(m.f)} (~${t.estimate_days || 1}d)${isCrit ? " · CAMINO CRÍTICO" : ""}</title></rect>`;
+    if (t.assignee) svg += `<text x="${x(m.f) + 5}" y="${y + 12}" fill="#8a93a6" font-size="10">${esc(t.assignee.slice(0, 14))}</text>`;
+  });
+  const end = plan.projectEnd ? `fin estimado del proyecto: <b>${fmtDate(plan.projectEnd)}</b> · ` : "";
+  host.innerHTML = `<div class="muted small" style="margin-bottom:6px">${end}borde rojo = camino crítico · hechas con fechas reales · clic en ~Nd de una tarea para estimar</div>` +
+    `<div class="graph-wrap"><svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">${svg}</svg></div>`;
+}
+
 /* ---------- diagrama de dependencias (SVG, sin librerías) ---------- */
-function renderDepGraph() {
+function renderDepGraph(plan) {
   const host = $("#depGraph");
   if (!host) return;
   const deps = state.deps || [];
@@ -126,17 +226,19 @@ function renderDepGraph() {
     : t.status === "in_progress" ? "#e0a83c"
     : isBlocked(t) ? "#e05c5c" : "#8a93a6";
 
+  const critical = id => plan && plan.crit && plan.crit.has(id);
   let svg = "";
   for (const d of deps) {
     const a = pos[d.depends_on_id], b = pos[d.task_id];
     if (!a || !b) continue;
+    const hot = critical(d.task_id) && critical(d.depends_on_id);
     const x1 = a.x + NW / 2, y1 = a.y + NH, x2 = b.x + NW / 2, y2 = b.y;
-    svg += `<path d="M${x1},${y1} C${x1},${y1 + 36} ${x2},${y2 - 36} ${x2},${y2}" fill="none" stroke="#2a3348" stroke-width="1.5" marker-end="url(#arr)"/>`;
+    svg += `<path d="M${x1},${y1} C${x1},${y1 + 36} ${x2},${y2 - 36} ${x2},${y2}" fill="none" stroke="${hot ? "#e05c5c" : "#2a3348"}" stroke-width="${hot ? 2.4 : 1.5}" marker-end="url(#arr)"/>`;
   }
   for (const n of nodes) {
     const p = pos[n.id], c = col(n);
     const label = n.title.length > 21 ? n.title.slice(0, 20) + "…" : n.title;
-    svg += `<g><rect x="${p.x}" y="${p.y}" width="${NW}" height="${NH}" rx="8" fill="#1d2537" stroke="${c}" stroke-width="1.6"/>
+    svg += `<g><rect x="${p.x}" y="${p.y}" width="${NW}" height="${NH}" rx="8" fill="#1d2537" stroke="${c}" stroke-width="${critical(n.id) ? 3 : 1.6}"/>
       <circle cx="${p.x + 13}" cy="${p.y + NH / 2}" r="4" fill="${c}"/>
       <text x="${p.x + 24}" y="${p.y + NH / 2 + 4}" fill="#e8ecf4" font-size="11">${esc(label)}</text>
       <title>${esc(n.title)} — ${n.status}${isBlocked(n) ? " (bloqueada)" : ""}</title></g>`;
@@ -148,6 +250,11 @@ function renderDepGraph() {
 
 function render() {
   const { layers, tasks, decisions, events } = state;
+  const plan = computeSchedule();
+
+  // sincronizar selects de filtros
+  const flt = getFilters();
+  if ($("#fWho")) { $("#fWho").value = flt.who || ""; $("#fSt").value = flt.st || ""; }
 
   // global + pipeline
   const gp = pct(tasks);
@@ -180,20 +287,42 @@ function render() {
     sec.innerHTML = `
       <div class="layer-head"><h2>${esc(l.title)}</h2><span class="sub">${esc(l.subtitle)}</span></div>
       <div class="layer-bar"><div class="layer-fill" style="width:${pct(lt)}%"></div></div>`;
-    // Raíces primero; bajo cada una, sus subtareas (1 nivel).
-    const ids = new Set(lt.map(t => t.id));
-    const roots = lt.filter(t => !t.parent_id || !ids.has(t.parent_id));
-    for (const t of roots) {
-      sec.appendChild(taskRow(t, false));
-      for (const s of lt.filter(x => x.parent_id === t.id)) sec.appendChild(taskRow(s, true));
-    }
-    const add = document.createElement("button");
-    add.className = "add-task"; add.textContent = "+ añadir tarea";
-    add.onclick = async () => {
-      const title = prompt("Título de la nueva tarea:");
-      if (title) await mutate("POST", "api/tasks", { layer_id: l.id, title });
+    // cabecera plegable con contador
+    const head = sec.querySelector(".layer-head");
+    const isCol = getCollapsed().has(l.id);
+    const caret = document.createElement("span");
+    caret.className = "caret"; caret.textContent = isCol ? "▸" : "▾";
+    head.prepend(caret);
+    const count = document.createElement("span");
+    count.className = "layer-count";
+    count.textContent = `${lt.filter(t => t.status === "done").length}/${lt.length}`;
+    head.appendChild(count);
+    head.style.cursor = "pointer";
+    head.onclick = () => {
+      const c = getCollapsed();
+      c.has(l.id) ? c.delete(l.id) : c.add(l.id);
+      localStorage.setItem("roadmap_collapsed", JSON.stringify([...c]));
+      render();
     };
-    sec.appendChild(add);
+
+    if (!isCol) {
+      // Raíces primero; bajo cada una, sus subtareas (1 nivel). Filtros activos.
+      const ids = new Set(lt.map(t => t.id));
+      const roots = lt.filter(t => !t.parent_id || !ids.has(t.parent_id));
+      for (const t of roots) {
+        const kids = lt.filter(x => x.parent_id === t.id);
+        if (!taskMatches(t) && !kids.some(taskMatches)) continue;
+        sec.appendChild(taskRow(t, false));
+        for (const s of kids) if (taskMatches(s) || taskMatches(t)) sec.appendChild(taskRow(s, true));
+      }
+      const add = document.createElement("button");
+      add.className = "add-task"; add.textContent = "+ añadir tarea";
+      add.onclick = async () => {
+        const title = prompt("Título de la nueva tarea:");
+        if (title) await mutate("POST", "api/tasks", { layer_id: l.id, title });
+      };
+      sec.appendChild(add);
+    }
     cont.appendChild(sec);
   }
 
@@ -214,7 +343,8 @@ function render() {
     dv.appendChild(el);
   }
 
-  renderDepGraph();
+  renderGantt(plan);
+  renderDepGraph(plan);
 
   // historial
   const ev = $("#events");
@@ -304,7 +434,26 @@ function taskRow(t, isSub) {
     if (confirm(`¿Eliminar «${t.title}»?`)) mutate("DELETE", `api/tasks/${t.id}`);
   };
 
-  row.append(st, body, asg);
+  // estimación / fechas fijas (alimenta el Gantt)
+  const est = document.createElement("span");
+  est.className = "est-chip";
+  est.textContent = `~${t.estimate_days || 1}d${t.start_date || t.due_date ? " 📌" : ""}`;
+  est.title = "Estimación y fechas (clic para editar)";
+  est.onclick = () => {
+    const v = prompt(
+      "Estimación:\n  2                      → 2 días\n  2 2026-07-10           → 2 días, no antes del 10-jul\n  2026-07-10..2026-07-12 → rango fijo\n  x                      → quitar fechas fijas",
+      t.estimate_days || 1);
+    if (v == null) return;
+    const s = String(v).trim();
+    if (s === "x") return mutate("PATCH", `api/tasks/${t.id}`, { start_date: null, due_date: null });
+    const range = s.match(/^(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})$/);
+    if (range) return mutate("PATCH", `api/tasks/${t.id}`, { start_date: range[1], due_date: range[2] });
+    const m = s.match(/^([\d.]+)(?:\s+(\d{4}-\d{2}-\d{2}))?$/);
+    if (m) return mutate("PATCH", `api/tasks/${t.id}`, { estimate_days: parseFloat(m[1]), start_date: m[2] || null });
+    toast("Formato no reconocido", true);
+  };
+
+  row.append(st, body, est, asg);
   if (!isSub) {
     const sub = document.createElement("button");
     sub.className = "add-sub"; sub.textContent = "+sub"; sub.title = "Añadir subtarea";

--- a/tools/roadmap-web/static/index.html
+++ b/tools/roadmap-web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Robocar · Roadmap TFM</title>
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚗</text></svg>">
 </head>
 <body>
@@ -24,7 +24,29 @@
   </header>
 
   <main>
+    <div class="filterbar">
+      <select id="fWho" onchange="setFilters({...getFilters(), who: this.value})">
+        <option value="">👥 todos</option>
+        <option value="Rubén">Rubén</option>
+        <option value="Antonio">Antonio</option>
+        <option value="Claude">Claude</option>
+        <option value="(sin)">sin asignar</option>
+      </select>
+      <select id="fSt" onchange="setFilters({...getFilters(), st: this.value})">
+        <option value="">estado: todos</option>
+        <option value="pending">pendientes</option>
+        <option value="in_progress">en curso</option>
+        <option value="done">hechas</option>
+      </select>
+      <span class="muted small">los filtros aplican a capas y Gantt · clic en el título de una capa para plegarla</span>
+    </div>
+
     <section id="layers"></section>
+
+    <section class="panel">
+      <h2>Gantt · auto-programado por dependencias</h2>
+      <div id="gantt"><div class="muted">cargando…</div></div>
+    </section>
 
     <section class="panel">
       <h2>Diagrama de dependencias</h2>
@@ -45,6 +67,6 @@
   <footer>
     Estado compartido · clic en el estado de una tarea para ciclarlo · doble clic en un texto para editarlo
   </footer>
-  <script src="app.js?v=3"></script>
+  <script src="app.js?v=4"></script>
 </body>
 </html>

--- a/tools/roadmap-web/static/index.html
+++ b/tools/roadmap-web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Robocar · Roadmap TFM</title>
-  <link rel="stylesheet" href="style.css?v=2">
+  <link rel="stylesheet" href="style.css?v=3">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚗</text></svg>">
 </head>
 <body>
@@ -27,6 +27,11 @@
     <section id="layers"></section>
 
     <section class="panel">
+      <h2>Diagrama de dependencias</h2>
+      <div id="depGraph" class="graph-wrap"><div class="muted">cargando…</div></div>
+    </section>
+
+    <section class="panel">
       <h2>Decisiones de diseño</h2>
       <div id="decisions" class="decisions"></div>
     </section>
@@ -40,6 +45,6 @@
   <footer>
     Estado compartido · clic en el estado de una tarea para ciclarlo · doble clic en un texto para editarlo
   </footer>
-  <script src="app.js?v=2"></script>
+  <script src="app.js?v=3"></script>
 </body>
 </html>

--- a/tools/roadmap-web/static/style.css
+++ b/tools/roadmap-web/static/style.css
@@ -124,6 +124,26 @@ main { padding: 18px clamp(16px, 4vw, 48px) 40px; display: grid; gap: 18px; }
 .graph-wrap { overflow-x: auto; padding: 4px 0; }
 .graph-wrap svg { display: block; margin: 0 auto; }
 
+/* filtros y plegado */
+.filterbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.filterbar select {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--line);
+  border-radius: 8px; padding: 6px 10px; font-size: .85rem;
+}
+.caret { color: var(--muted); margin-right: 6px; font-size: .9rem; }
+.layer-count {
+  margin-left: auto; font-size: .75rem; color: var(--muted);
+  background: var(--panel-2); border-radius: 12px; padding: 2px 10px;
+}
+
+/* estimación */
+.est-chip {
+  flex: none; font-size: .72rem; color: var(--muted); cursor: pointer;
+  background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px;
+  padding: 3px 8px; margin-top: 2px; white-space: nowrap;
+}
+.est-chip:hover { color: var(--accent); border-color: var(--accent); }
+
 .events { list-style: none; margin: 0; padding: 0; font-size: .82rem; max-height: 260px; overflow-y: auto; }
 .events li { padding: 5px 0; border-top: 1px solid var(--line); color: var(--muted); }
 .events li:first-child { border-top: none; }

--- a/tools/roadmap-web/static/style.css
+++ b/tools/roadmap-web/static/style.css
@@ -121,6 +121,9 @@ main { padding: 18px clamp(16px, 4vw, 48px) 40px; display: grid; gap: 18px; }
 .dstatus.open { background: #232a3c; color: var(--pending); }
 .decision .ddetail { color: var(--muted); font-size: .8rem; margin-top: 5px; }
 
+.graph-wrap { overflow-x: auto; padding: 4px 0; }
+.graph-wrap svg { display: block; margin: 0 auto; }
+
 .events { list-style: none; margin: 0; padding: 0; font-size: .82rem; max-height: 260px; overflow-y: auto; }
 .events li { padding: 5px 0; border-top: 1px solid var(--line); color: var(--muted); }
 .events li:first-child { border-top: none; }


### PR DESCRIPTION
## Qué añade (v3 completa)
- **Diagrama de dependencias** (SVG sin librerías): capas topológicas, colores por estado, tooltip
- **Gantt auto-programado**: camino crítico (CPM) sobre las dependencias + estimación editable por tarea (chip `~Nd`) + fechas fijas opcionales (`2026-07-10..2026-07-12`). Pasado con fechas reales; futuro se recalcula solo. Muestra **fin estimado del proyecto**
- **Filtros** por persona/estado (persistidos) · **capas plegables** con contadores
- **Camino crítico resaltado** en Gantt y grafo
- Backend: migración no destructiva (`estimate_days`, `start_date`, `due_date`, `done_at`)
- **MkDocs centralizado**: `roadmap.md` queda solo conceptual + enlace al tablero

## Verificación
Local con BD real migrada: 0 errores JS, Gantt con camino crítico Cartographer→mapa→Nav2→TEB y fin estimado. `mkdocs build --strict` limpio. Capturas en la sesión de trabajo.

## Tras el merge
Despliegue al VPS (`git pull && docker compose up -d --build`) — me encargo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)