### PR TITLE
0.5 Sanear /imu

### DIFF
--- a/src/robocar_pkg/robocar_pkg/accelerometer_node.py
+++ b/src/robocar_pkg/robocar_pkg/accelerometer_node.py
@@ -1,41 +1,92 @@
+import math
+
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import Imu
 from lib import MPU6050
-from time import sleep
+
+DEG2RAD = math.pi / 180.0
 
 
 class ImuPublisher(Node):
+    """Publica sensor_msgs/Imu del MPU6050 (0x68) saneado para fusion (EKF).
+
+    - linear_acceleration en m/s^2 (el driver ya lo entrega asi).
+    - angular_velocity convertida de deg/s (driver) a rad/s (convencion ROS).
+    - header con timestamp y frame_id.
+    - orientation NO disponible (el MPU6050 no tiene magnetometro): se marca
+      orientation_covariance[0] = -1.0 segun la convencion de sensor_msgs/Imu.
+    - covarianzas de gyro/accel: diagonal con varianzas parametrizables
+      (defaults tipo datasheet; afinar midiendo el ruido en reposo).
+    """
 
     def __init__(self):
         super().__init__('accelerometer_node')
+
+        # --- Parametros ---
+        self.declare_parameter('i2c_address', 0x68)
+        self.declare_parameter('frame_id', 'imu_link')
+        self.declare_parameter('publish_rate_hz', 50.0)
+        self.declare_parameter('angular_velocity_variance', 0.0004)    # (rad/s)^2  ~ std 0.02
+        self.declare_parameter('linear_acceleration_variance', 0.01)   # (m/s^2)^2  ~ std 0.1
+
+        addr = self.get_parameter('i2c_address').value
+        self.frame_id = self.get_parameter('frame_id').value
+        rate = float(self.get_parameter('publish_rate_hz').value)
+        av_var = float(self.get_parameter('angular_velocity_variance').value)
+        la_var = float(self.get_parameter('linear_acceleration_variance').value)
+
+        self.mpu = MPU6050.mpu6050(addr)
         self.publisher_ = self.create_publisher(Imu, 'imu', 10)
-        self.mpu = MPU6050.mpu6050(0x68)
-        timer_period = 0.5  # seconds
-        self.timer = self.create_timer(timer_period, self.timer_callback)
+
+        # Covarianzas fijas (diagonal 3x3, row-major). orientation: no disponible.
+        self.orientation_cov = [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        self.angular_velocity_cov = [av_var, 0.0, 0.0, 0.0, av_var, 0.0, 0.0, 0.0, av_var]
+        self.linear_acceleration_cov = [la_var, 0.0, 0.0, 0.0, la_var, 0.0, 0.0, 0.0, la_var]
+
+        self.timer = self.create_timer(1.0 / rate, self.timer_callback)
+        self.get_logger().info(
+            'accelerometer_node listo (addr=0x%02X, frame=%s, %.0f Hz)'
+            % (addr, self.frame_id, rate))
 
     def timer_callback(self):
-        imu_msg = Imu()
+        try:
+            accel = self.mpu.get_accel_data()   # m/s^2
+            gyro = self.mpu.get_gyro_data()     # deg/s
+        except Exception as e:
+            self.get_logger().warn('Error leyendo el MPU6050: %s' % e)
+            return
 
-        accel_data = self.mpu.get_accel_data()
-        imu_msg.linear_acceleration.x = round(accel_data['x'], 2)
-        imu_msg.linear_acceleration.y = round(accel_data['y'], 2)
-        imu_msg.linear_acceleration.z = round(accel_data['z'], 2)
+        msg = Imu()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self.frame_id
 
-        gyro_data = self.mpu.get_gyro_data()
-        imu_msg.angular_velocity.x = round(gyro_data['x'], 2)
-        imu_msg.angular_velocity.y = round(gyro_data['y'], 2)
-        imu_msg.angular_velocity.z = round(gyro_data['z'], 2)
+        msg.linear_acceleration.x = accel['x']
+        msg.linear_acceleration.y = accel['y']
+        msg.linear_acceleration.z = accel['z']
 
-        self.publisher_.publish(imu_msg)
+        msg.angular_velocity.x = gyro['x'] * DEG2RAD
+        msg.angular_velocity.y = gyro['y'] * DEG2RAD
+        msg.angular_velocity.z = gyro['z'] * DEG2RAD
+
+        msg.orientation_covariance = self.orientation_cov
+        msg.angular_velocity_covariance = self.angular_velocity_cov
+        msg.linear_acceleration_covariance = self.linear_acceleration_cov
+
+        self.publisher_.publish(msg)
 
 
 def main(args=None):
     rclpy.init(args=args)
-    imu_publisher = ImuPublisher()
-    rclpy.spin(imu_publisher)
-    imu_publisher.destroy_node()
-    rclpy.shutdown()
+    node = ImuPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 0.5 Sanear /imu

Sanea el mensaje `/imu` del `accelerometer_node` (MPU6050) para que sea consumible por fusion (robot_localization / EKF).

### Cambios
- **header**: timestamp + `frame_id=imu_link`.
- **Unidades**: giroscopio deg/s -> rad/s (convencion `sensor_msgs/Imu`).
- **Covarianzas**: `orientation_covariance[0] = -1` (MPU6050 sin orientacion) + diagonal de gyro (0.0004) y accel (0.01) como parametros.
- **Frecuencia**: 50 Hz (parametrizable).
- Se elimina el `round()` que perdia precision; teardown limpio.
- No se toca el driver `lib/MPU6050.py`.

### Validacion (robot en reposo)
- 51 Hz estable, **0 errores I2C** (bus compartido con energy/encoder/car_control).
- Giroscopio en rad/s, header y covarianzas correctas.

### Pendiente (fuera de alcance, tarea aparte)
- Calibracion de escala/bias del acelerometro: |a| ~ 7.97 m/s2 en reposo (esperado ~9.81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)