### PR TITLE
Odometria plan B: fusion encoder + IMU (EKF)

### DIFF
--- a/src/robocar_pkg/config/ekf.yaml
+++ b/src/robocar_pkg/config/ekf.yaml
@@ -1,0 +1,36 @@
+# EKF de robot_localization: fusion encoder (vx) + IMU (yaw rate) -> odom->base_link
+# Plan B de odometria (D2->B). Robot planar Ackermann.
+ekf_filter_node:
+  ros__parameters:
+    frequency: 30.0
+    sensor_timeout: 0.2
+    two_d_mode: true
+    publish_tf: true
+
+    map_frame: map
+    odom_frame: odom
+    base_link_frame: base_link
+    world_frame: odom
+
+    # --- Encoder: velocidad lineal vx (del adaptador wheel_twistcov_node) ---
+    twist0: wheel_speed_cov
+    # [x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az]
+    twist0_config: [false, false, false,
+                    false, false, false,
+                    true,  false, false,
+                    false, false, false,
+                    false, false, false]
+    twist0_queue_size: 10
+    twist0_nodelay: true
+
+    # --- IMU: velocidad angular en z (yaw rate). accel NO se fusiona (bias sin calibrar) ---
+    imu0: imu
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+    imu0_differential: false
+    imu0_relative: false
+    imu0_queue_size: 20
+    imu0_remove_gravitational_acceleration: true

--- a/src/robocar_pkg/launch/ekf.launch.py
+++ b/src/robocar_pkg/launch/ekf.launch.py
@@ -1,0 +1,28 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    ekf_config = os.path.join(
+        get_package_share_directory('robocar_pkg'), 'config', 'ekf.yaml')
+
+    return LaunchDescription([
+        # Adaptador: /wheel_speed (TwistStamped) -> /wheel_speed_cov (con covarianza)
+        Node(
+            package='robocar_pkg',
+            executable='wheel_twistcov_node',
+            name='wheel_twistcov_node',
+            output='screen',
+        ),
+        # EKF: fusiona encoder (vx) + IMU (yaw rate) -> odom -> base_link
+        Node(
+            package='robot_localization',
+            executable='ekf_node',
+            name='ekf_filter_node',
+            output='screen',
+            parameters=[ekf_config],
+        ),
+    ])

--- a/src/robocar_pkg/package.xml
+++ b/src/robocar_pkg/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/robocar_pkg/robocar_pkg/wheel_twistcov_node.py
+++ b/src/robocar_pkg/robocar_pkg/wheel_twistcov_node.py
@@ -1,0 +1,68 @@
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import TwistStamped, TwistWithCovarianceStamped
+
+
+class WheelTwistCov(Node):
+    """Adapta /wheel_speed (TwistStamped del encoder) a TwistWithCovarianceStamped
+    para que robot_localization (EKF) pueda consumir la velocidad de la rueda.
+
+    El EKF no acepta TwistStamped (sin covarianza). Se republica la vx del
+    encoder con una varianza configurable; el resto de componentes llevan
+    varianza grande (ademas el twist_config del EKF solo selecciona vx).
+
+    El encoder es de un solo canal (sin signo): la velocidad es siempre >= 0.
+    """
+
+    BIG = 1e6
+
+    def __init__(self):
+        super().__init__('wheel_twistcov_node')
+        self.declare_parameter('input_topic', 'wheel_speed')
+        self.declare_parameter('output_topic', 'wheel_speed_cov')
+        self.declare_parameter('frame_id', 'base_link')
+        self.declare_parameter('vx_variance', 0.02)     # (m/s)^2
+
+        inp = self.get_parameter('input_topic').value
+        out = self.get_parameter('output_topic').value
+        self.frame_id = self.get_parameter('frame_id').value
+        self.vx_var = float(self.get_parameter('vx_variance').value)
+
+        self.pub = self.create_publisher(TwistWithCovarianceStamped, out, 10)
+        self.sub = self.create_subscription(TwistStamped, inp, self.callback, 10)
+        self.get_logger().info(
+            'wheel_twistcov_node: %s (TwistStamped) -> %s (TwistWithCovarianceStamped), frame=%s'
+            % (inp, out, self.frame_id))
+
+    def callback(self, msg):
+        out = TwistWithCovarianceStamped()
+        out.header.stamp = msg.header.stamp
+        out.header.frame_id = self.frame_id
+        out.twist.twist = msg.twist
+
+        cov = [0.0] * 36
+        cov[0] = self.vx_var     # vx
+        cov[7] = self.BIG        # vy
+        cov[14] = self.BIG       # vz
+        cov[21] = self.BIG       # vroll
+        cov[28] = self.BIG       # vpitch
+        cov[35] = self.BIG       # vyaw
+        out.twist.covariance = cov
+        self.pub.publish(out)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = WheelTwistCov()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/robocar_pkg/setup.py
+++ b/src/robocar_pkg/setup.py
@@ -1,3 +1,5 @@
+import os
+from glob import glob
 from setuptools import find_packages, setup
 
 package_name = 'robocar_pkg'
@@ -10,6 +12,8 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
@@ -27,6 +31,7 @@ setup(
             'distance_node = robocar_pkg.distance_node:main',
             'processing_node = robocar_pkg.processing_node:main',
             'encoder_node = robocar_pkg.encoder_node:main',
+            'wheel_twistcov_node = robocar_pkg.wheel_twistcov_node:main',
         ],
     },
 )


### PR DESCRIPTION
## Odometria plan B - fusion encoder + IMU (EKF)

Implementa la odometria del **plan B (D2->B)**: fusiona la velocidad del encoder y el giroscopio del IMU con un EKF de `robot_localization` -> `odom -> base_link` + `/odometry/filtered`.

### Componentes
- **`wheel_twistcov_node`**: adapta `/wheel_speed` (`TwistStamped`, encoder) a `TwistWithCovarianceStamped` (`/wheel_speed_cov`) con covarianza; el EKF no acepta `TwistStamped`.
- **`config/ekf.yaml`**: `robot_localization` EKF 2D (`two_d_mode`), fusiona `vx` (encoder) + `yaw rate` (IMU). El acelerometro NO se fusiona (bias sin calibrar).
- **`launch/ekf.launch.py`**: lanza el adaptador + `ekf_node`.
- **`setup.py` / `package.xml`**: instala `launch/` y `config/`, entry point del adaptador, `exec_depend robot_localization`.

### Validacion (en el robot)
- `robot_localization` instalado; el EKF produce **`/odometry/filtered`** fusionando encoder + IMU **sin errores** (IMU transformado via `base_link->imu_link` del URDF).
- **Posicion estable en reposo** (x=y=0).
- :warning: **El yaw deriva ~3.3 deg/s en reposo** por el **bias del giroscopio sin calibrar**. Es calibracion (follow-up), no un fallo del pipeline.

### Pendientes (follow-up)
- Quitar el **bias del giroscopio** (calibracion IMU) para eliminar la deriva de yaw.
- **Validar rodando** un recorrido conocido (recto + giro) y medir deriva.
- **Coexistencia TF**: la config lleva `publish_tf: true` (el EKF posee `odom->base_link`). Para plan B real, Cartographer debe publicar `map->odom` (no `odom->base_link`). En la validacion se uso `publish_tf:=false` para no chocar con el TF en vivo.
- (Mejora) Publicar el angulo de direccion + modelo-bicicleta como entrada extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)