### PR TITLE
IMU: auto-calibracion del bias del giroscopio

### DIFF
--- a/src/robocar_pkg/robocar_pkg/accelerometer_node.py
+++ b/src/robocar_pkg/robocar_pkg/accelerometer_node.py
@@ -16,8 +16,11 @@ class ImuPublisher(Node):
     - header con timestamp y frame_id.
     - orientation NO disponible (el MPU6050 no tiene magnetometro): se marca
       orientation_covariance[0] = -1.0 segun la convencion de sensor_msgs/Imu.
-    - covarianzas de gyro/accel: diagonal con varianzas parametrizables
-      (defaults tipo datasheet; afinar midiendo el ruido en reposo).
+    - covarianzas de gyro/accel: diagonal con varianzas parametrizables.
+    - bias del giroscopio: se auto-calibra al arrancar promediando N muestras
+      (el robot debe estar EN REPOSO); despues se resta de la lectura. Evita la
+      deriva de yaw en la odometria EKF. Se puede fijar un bias estatico con los
+      parametros gyro_bias_* y calibrate_gyro=false.
     """
 
     def __init__(self):
@@ -29,12 +32,27 @@ class ImuPublisher(Node):
         self.declare_parameter('publish_rate_hz', 50.0)
         self.declare_parameter('angular_velocity_variance', 0.0004)    # (rad/s)^2  ~ std 0.02
         self.declare_parameter('linear_acceleration_variance', 0.01)   # (m/s^2)^2  ~ std 0.1
+        self.declare_parameter('calibrate_gyro', True)
+        self.declare_parameter('calibration_samples', 100)             # ~2 s a 50 Hz
+        self.declare_parameter('gyro_bias_x', 0.0)                     # rad/s (si calibrate_gyro=false)
+        self.declare_parameter('gyro_bias_y', 0.0)
+        self.declare_parameter('gyro_bias_z', 0.0)
 
         addr = self.get_parameter('i2c_address').value
         self.frame_id = self.get_parameter('frame_id').value
         rate = float(self.get_parameter('publish_rate_hz').value)
         av_var = float(self.get_parameter('angular_velocity_variance').value)
         la_var = float(self.get_parameter('linear_acceleration_variance').value)
+
+        self.calibrating = bool(self.get_parameter('calibrate_gyro').value)
+        self.cal_samples = int(self.get_parameter('calibration_samples').value)
+        self.gyro_bias = [
+            float(self.get_parameter('gyro_bias_x').value),
+            float(self.get_parameter('gyro_bias_y').value),
+            float(self.get_parameter('gyro_bias_z').value),
+        ]
+        self._cal_sum = [0.0, 0.0, 0.0]
+        self._cal_n = 0
 
         self.mpu = MPU6050.mpu6050(addr)
         self.publisher_ = self.create_publisher(Imu, 'imu', 10)
@@ -45,6 +63,10 @@ class ImuPublisher(Node):
         self.linear_acceleration_cov = [la_var, 0.0, 0.0, 0.0, la_var, 0.0, 0.0, 0.0, la_var]
 
         self.timer = self.create_timer(1.0 / rate, self.timer_callback)
+        if self.calibrating:
+            self.get_logger().info(
+                'accelerometer_node: calibrando bias del giroscopio con %d muestras '
+                '(mantener el robot QUIETO)...' % self.cal_samples)
         self.get_logger().info(
             'accelerometer_node listo (addr=0x%02X, frame=%s, %.0f Hz)'
             % (addr, self.frame_id, rate))
@@ -57,6 +79,24 @@ class ImuPublisher(Node):
             self.get_logger().warn('Error leyendo el MPU6050: %s' % e)
             return
 
+        gx = gyro['x'] * DEG2RAD
+        gy = gyro['y'] * DEG2RAD
+        gz = gyro['z'] * DEG2RAD
+
+        # Auto-calibracion del bias del giroscopio (robot en reposo al arrancar)
+        if self.calibrating:
+            self._cal_sum[0] += gx
+            self._cal_sum[1] += gy
+            self._cal_sum[2] += gz
+            self._cal_n += 1
+            if self._cal_n >= self.cal_samples:
+                self.gyro_bias = [s / self._cal_n for s in self._cal_sum]
+                self.calibrating = False
+                self.get_logger().info(
+                    'Bias del giroscopio calibrado (rad/s): x=%.4f y=%.4f z=%.4f'
+                    % (self.gyro_bias[0], self.gyro_bias[1], self.gyro_bias[2]))
+            return  # no publicar durante la calibracion
+
         msg = Imu()
         msg.header.stamp = self.get_clock().now().to_msg()
         msg.header.frame_id = self.frame_id
@@ -65,9 +105,9 @@ class ImuPublisher(Node):
         msg.linear_acceleration.y = accel['y']
         msg.linear_acceleration.z = accel['z']
 
-        msg.angular_velocity.x = gyro['x'] * DEG2RAD
-        msg.angular_velocity.y = gyro['y'] * DEG2RAD
-        msg.angular_velocity.z = gyro['z'] * DEG2RAD
+        msg.angular_velocity.x = gx - self.gyro_bias[0]
+        msg.angular_velocity.y = gy - self.gyro_bias[1]
+        msg.angular_velocity.z = gz - self.gyro_bias[2]
 
         msg.orientation_covariance = self.orientation_cov
         msg.angular_velocity_covariance = self.angular_velocity_cov


### PR DESCRIPTION
## IMU: auto-calibracion del bias del giroscopio

Elimina la deriva de yaw en la odometria (EKF plan B) auto-calibrando el bias del giroscopio.

### Cambio
`accelerometer_node` promedia N muestras al arrancar (robot EN REPOSO) para estimar el bias del giroscopio y lo resta de las lecturas.

**Parametros nuevos**:
- `calibrate_gyro` (default `true`)
- `calibration_samples` (default 100, ~2 s a 50 Hz)
- `gyro_bias_x/y/z` (override estatico si `calibrate_gyro=false`)

### Validacion (robot en reposo)
| | media de wz |
|---|---|
| Antes | ~0.058 rad/s (**3.3 deg/s** de deriva) |
| Despues | -0.0016 rad/s (**0.09 deg/s**) -> ~37x menos |

### Relacion
Complementa el PR de odometria plan B (EKF encoder+IMU): sin este fix el yaw derivaba ~3.3 deg/s en reposo por el bias del giroscopio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)